### PR TITLE
Autoload Encryptor

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -8,6 +8,7 @@ require 'responders'
 
 module Devise
   autoload :Delegator,          'devise/delegator'
+  autoload :Encryptor,          'devise/encryptor'
   autoload :FailureApp,         'devise/failure_app'
   autoload :OmniAuth,           'devise/omniauth'
   autoload :ParameterFilter,    'devise/parameter_filter'


### PR DESCRIPTION
Spring started complaining about Devise::Encryptor being uninitialized so I figured that it should be autoloaded.
